### PR TITLE
Remove hit counter from README.md and INDEX_TEMPLATE.md

### DIFF
--- a/.github/INDEX_TEMPLATE.md
+++ b/.github/INDEX_TEMPLATE.md
@@ -1,7 +1,6 @@
 # Locatarr
 
 <p>
- <a href="https://hits.seeyoufarm.com"><img alt="Hits" src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2FLocatarr%2FLocatarr&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false" /></a>
  <a href="https://github.com/Locatarr/Locatarr/issues"><img alt="contributions welcome" src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat" /></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Locatarr
 
 <p>
- <a href="https://hits.seeyoufarm.com"><img alt="Hits" src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2FLocatarr%2FLocatarr&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false" /></a>
  <a href="https://github.com/Locatarr/locatarr.github.io/issues"><img alt="contributions welcome" src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat" /></a>
 </p>
 


### PR DESCRIPTION
hits.seeyoufarm.com is no longer available and the [GitHub repository](https://github.com/gjbae1212/hit-counter) has been archived.

This PR removes the hit counter from both `README.md` and `INDEX_TEMPLATE.md`.
