### PR TITLE
Add retraktarr to arr-services.json

### DIFF
--- a/arr-services.json
+++ b/arr-services.json
@@ -177,6 +177,11 @@
 			"github_slug": "thomst08/requestrr"
 		},
 		{
+			"name": "retraktarr",
+			"description": "retraktarr is a reverse Trakt.tv list implementation for Radarr/Sonarr that creates Trakt.tv lists for your movies/series using APIs.",
+			"github_slug": "zakkarry/retraktarr"
+		},
+		{
 			"name": "Rollarr",
 			"description": "Automatic Pre-roll script with a GUI for Plex (Archived)",
 			"github_slug": "red4dj/Rollarr"


### PR DESCRIPTION
This PR adds retraktarr to the arr list. They've (Trakt.tv) recently changed their monetization structure to limit the list size and count a fair bit, but it still might be useful to some.

I've been considering adding Letterboxd support, but haven't had the time...either way, it's an "arr" :P

https://github.com/zakkarry/retraktarr

<hr>

retraktarr is a "reverse" [Trakt.tv](https://www.trakt.tv/) list implementation for [Radarr](https://radarr.video/)/[Sonarr](https://sonarr.tv/) that creates [Trakt.tv](https://www.trakt.tv/) lists for your movies/series using APIs.