### PR TITLE
Remove Readarr

### DIFF
--- a/arr-services.json
+++ b/arr-services.json
@@ -162,11 +162,6 @@
 			"subreddit": "r/Radarr"
 		},
 		{
-			"name": "Readarr",
-			"description": "Automates & manages **ebooks**",
-			"github_slug": "Readarr/Readarr"
-		},
-		{
 			"name": "Recyclarr",
 			"description": "Automatically sync TRaSH Guides to your Sonarr and Radarr instances",
 			"github_slug": "recyclarr/recyclarr"


### PR DESCRIPTION
Readarr has been deprecated and is a non-working state due to metadata server changes

Source: https://github.com/Readarr/Readarr/blob/0b79d3000d4e5f8425f499970b0190e2c421fceb/README.md
